### PR TITLE
feat(db): Supabase profiles schema + RLS + API (/api/profile) [#18]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ npm install
 npm run dev
 ```
 
+## Supabase: profiles テーブルとRLSのセットアップ（Issue #18）
+
+1. Supabase のプロジェクトを用意し、SQL Editor を開く
+2. `docs/sql/profiles.sql` の内容を貼り付けて実行
+    - `public.profiles` 作成
+    - RLS 有効化とポリシー（select/insert/update 自分のみ）
+    - `auth.users` への insert トリガーで `profiles` 自動作成
+3. 動作確認
+    - サインアップ → `public.profiles` に該当ユーザーの行が自動作成
+    - 認証後のAPI/クライアントから自分の row のみ取得/更新可能
+
+注意: 本番適用時は必要に応じてカラムを拡張し、マイグレーション管理（例: `supabase/migrations`）への移行を検討してください。
+```
+
 ### ビルド
 ```bash
 # 本番ビルド

--- a/docs/sql/profiles.sql
+++ b/docs/sql/profiles.sql
@@ -1,0 +1,66 @@
+-- Supabase: public.profiles schema, RLS and trigger
+-- Run in Supabase SQL editor (adjust schema/owner as needed)
+
+-- 1) Table
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  -- Minimal profile fields for onboarding baseline
+  display_name text,
+  grade text,
+  is_parent_dependent boolean,
+  employer_size text check (employer_size in ('small','medium','large','unknown')),
+  default_hourly_wage integer,
+  bracket integer check (bracket in (103,130,150))
+);
+
+-- 2) Timestamp update trigger
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+create trigger profiles_set_updated_at
+before update on public.profiles
+for each row execute procedure public.set_updated_at();
+
+-- 3) RLS
+alter table public.profiles enable row level security;
+
+-- Policy: users can select their own row
+create policy "Profiles are selectable by owner"
+  on public.profiles for select
+  using ( auth.uid() = id );
+
+-- Policy: users can insert their own row
+create policy "Profiles are insertable by owner"
+  on public.profiles for insert
+  with check ( auth.uid() = id );
+
+-- Policy: users can update their own row
+create policy "Profiles are updatable by owner"
+  on public.profiles for update
+  using ( auth.uid() = id )
+  with check ( auth.uid() = id );
+
+-- 4) Trigger to auto-create profile after signup
+-- Uses auth.users; create a function that inserts a row into profiles on new user
+create or replace function public.handle_new_user()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.profiles (id)
+  values (new.id)
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+-- If not exists, bind to auth.users table
+-- Note: On Supabase, this trigger is commonly created in the auth schema via SQL editor
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();


### PR DESCRIPTION
- 概要
  - Issue #18 の実装。Supabase に profiles を作成し、RLS とサインアップ時の自動作成トリガーを導入。Next.js 側にSSR/ClientのSupabase初期化と /api/profile（GET/PUT）を追加。
  - クライアントの認証連携（Issue #9）後にRLS下で自分のプロフィールのみ取得/更新可能。

- 変更点
  - profiles.sql 追加（テーブル・RLS・トリガー）
  - supabaseClient.ts 追加（ブラウザ）
  - supabaseServer.ts 追加（SSR, cookies連携）
  - route.ts 追加（GET/PUT）
  - README.md 追記（SQL適用・環境変数・確認手順）
  - 依存追加: @supabase/supabase-js, @supabase/ssr

- セットアップ
  1) Supabase SQL Editor で profiles.sql を実行
  2) .env.local に以下を設定
     NEXT_PUBLIC_SUPABASE_URL=あなたのURL
     NEXT_PUBLIC_SUPABASE_ANON_KEY=あなたのANON_KEY

- 動作確認
  - 認証（Issue #9）でログイン後:
    - GET /api/profile → 自分の行が返る
    - PUT /api/profile { profile: { grade: "大学2年", bracket: 130, ... } } → 自分の行のみ更新される（RLSで保護）

- 受け入れ基準の対応
  - 認証済ユーザーは自分の profiles のみ取得/更新できる: Done（RLS + APIで確認）
  - 新規サインアップ後に profiles 行が自動作成される: Done（auth.users → profiles トリガー）

- リスク/注意
  - 本番導入時はカラム拡張やマイグレーション管理（supabase/migrations）への移行を推奨
  - 既存データがある場合は移行SQLの用意が必要

- 関連
  - Closes #18
  - Blocked by/Depends on: ログイン／ログアウト #9（運用時の実利用のため）