### PR TITLE
feat(auth-ui): /login と /reset-password の最小実装 [#21]

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,96 @@
+"use client"
+import { useState } from 'react'
+import { getSupabaseClient } from '@/lib/supabaseClient'
+import Link from 'next/link'
+
 export default function LoginPage() {
+  const [mode, setMode] = useState<'signin' | 'signup'>(() => 'signin')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const canSubmit = email.trim().length > 3 && password.length >= 6 && !loading
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setMessage(null)
+    if (!canSubmit) return
+    setLoading(true)
+    try {
+      const supabase = getSupabaseClient()
+      if (mode === 'signin') {
+        const { error } = await supabase.auth.signInWithPassword({ email, password })
+        if (error) throw error
+        setMessage('ログインしました。ページが自動で遷移します。')
+        // ミドルウェアにより保護ページへ誘導される
+      } else {
+  const { error } = await supabase.auth.signUp({ email, password })
+        if (error) throw error
+        setMessage('サインアップが完了しました。メール確認が必要な場合は案内に従ってください。')
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'エラーが発生しました'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
     <main className="mx-auto max-w-md p-6">
-      <h1 className="text-xl font-semibold mb-4">ログイン</h1>
-      <p className="text-sm text-gray-600">Supabase 認証UIは今後実装します。ログイン後はプロフィール/オンボーディングに遷移します。</p>
+      <h1 className="text-xl font-semibold mb-4">{mode === 'signin' ? 'ログイン' : '新規登録'}</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">メールアドレス</label>
+          <input
+            type="email"
+            className="w-full rounded border px-3 py-2"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            autoComplete="email"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">パスワード</label>
+          <input
+            type="password"
+            className="w-full rounded border px-3 py-2"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={6}
+            autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
+          />
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {message && <p className="text-sm text-green-700">{message}</p>}
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+        >
+          {loading ? '送信中…' : mode === 'signin' ? 'ログイン' : '登録する'}
+        </button>
+
+        <div className="flex items-center justify-between text-sm">
+          <button
+            type="button"
+            className="text-blue-700 underline"
+            onClick={() => setMode((m) => (m === 'signin' ? 'signup' : 'signin'))}
+          >
+            {mode === 'signin' ? '新規登録はこちら' : 'ログインはこちら'}
+          </button>
+          <Link href="/reset-password" className="text-blue-700 underline">
+            パスワードをお忘れですか？
+          </Link>
+        </div>
+      </form>
     </main>
   )
 }

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,126 @@
+"use client"
+import { useSearchParams } from 'next/navigation'
+import { Suspense, useEffect, useState } from 'react'
+import { getSupabaseClient } from '@/lib/supabaseClient'
+
+function ResetPasswordInner() {
+  const params = useSearchParams()
+  const access_token = params.get('access_token')
+  const code = params.get('code')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [mode, setMode] = useState<'request' | 'update'>(access_token || code ? 'update' : 'request')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    setMode(access_token || code ? 'update' : 'request')
+  }, [access_token, code])
+
+  // If 'code' is present (newer Supabase flow), exchange it for a session
+  useEffect(() => {
+    const run = async () => {
+      if (!code) return
+      try {
+        const supabase = getSupabaseClient()
+        const { error } = await supabase.auth.exchangeCodeForSession(code)
+        if (error) {
+          setError(error.message)
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'エラーが発生しました'
+        setError(msg)
+      }
+    }
+    void run()
+  }, [code])
+
+  async function requestEmail(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setMessage(null)
+    if (!email) return
+    setLoading(true)
+    try {
+  const supabase = getSupabaseClient()
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: typeof window !== 'undefined' ? `${window.location.origin}/reset-password` : undefined,
+      })
+      if (error) throw error
+      setMessage('リセット用のメールを送信しました。メールの案内に従ってください。')
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'エラーが発生しました'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function updatePassword(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setMessage(null)
+    if (!password || password.length < 6) return
+    setLoading(true)
+    try {
+  const supabase = getSupabaseClient()
+  const { error } = await supabase.auth.updateUser({ password })
+      if (error) throw error
+      setMessage('パスワードを更新しました。ログイン画面に戻ってサインインしてください。')
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'エラーが発生しました'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-md p-6">
+      {mode === 'request' ? (
+        <form onSubmit={requestEmail} className="space-y-4">
+          <h1 className="text-xl font-semibold">パスワードをリセット</h1>
+          <p className="text-sm text-gray-600">メールアドレスにリセット用リンクを送信します。</p>
+          <input
+            type="email"
+            className="w-full rounded border px-3 py-2"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {message && <p className="text-sm text-green-700">{message}</p>}
+          <button type="submit" disabled={loading} className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-50">
+            {loading ? '送信中…' : 'メールを送る'}
+          </button>
+        </form>
+      ) : (
+        <form onSubmit={updatePassword} className="space-y-4">
+          <h1 className="text-xl font-semibold">新しいパスワードを設定</h1>
+          <input
+            type="password"
+            className="w-full rounded border px-3 py-2"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={6}
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {message && <p className="text-sm text-green-700">{message}</p>}
+          <button type="submit" disabled={loading} className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-50">
+            {loading ? '更新中…' : '更新する'}
+          </button>
+        </form>
+      )}
+    </main>
+  )
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={<main className="mx-auto max-w-md p-6">読み込み中…</main>}>
+      <ResetPasswordInner />
+    </Suspense>
+  )
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,5 +1,15 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { getSupabaseEnv } from './env';
 
-const { url, anon } = getSupabaseEnv();
-export const supabase = createClient(url, anon);
+let client: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+	if (client) return client;
+	const { url, anon } = getSupabaseEnv();
+	if (!url || !anon) {
+		// Avoid crashing at build; only throw when actually used at runtime
+		throw new Error('Supabase env is missing. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.');
+	}
+	client = createClient(url, anon);
+	return client;
+}


### PR DESCRIPTION
- 本文要点
  - 概要: メール/パスワードのサインイン/サインアップ、リセット要求と新PW設定、最新のcodeフロー対応
  - 受け入れ基準
    - サインアップ/サインイン成功で保護ページへ進める（ミドルウェアが誘導）
    - リセットメール→リンク→新パスワード設定が完了
  - セットアップ
    - .env.local に NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY 設定
    - Supabase Auth 設定でパスワードリセットのredirect URLを {origin}/reset-password に
  - 注意: 本番ではメールドメイン許可・テンプレ整備を推奨