### PR TITLE
feat(deploy): initial Vercel deployment setup with security headers

### DIFF
--- a/docs/issue-26-vercel-deploy.md
+++ b/docs/issue-26-vercel-deploy.md
@@ -1,0 +1,29 @@
+# Issue 26: Vercel デプロイ & 本番運用初期セットアップ\n\n## 目的\n認証・オンボーディング機能を含むアプリを Vercel にデプロイし、本番相当環境で動作/セキュリティ/観測の最低限を整備する。\n\n## スコープ (In)\n- Vercel プロジェクト作成 & GitHub リンク\n- 環境変数設定 (Supabase)\n- Supabase Auth リダイレクト設定更新 (本番URL)\n- E2E_MODE の本番無効化\n- セキュリティヘッダ (最小) 付与\n- デプロイ後の手動確認チェックリスト\n\n## アウトスコープ (Out)\n- 本格的な Observability (Sentry, Log 管理)\n- CI/CD ワークフロー (別Issue)\n- ドメインカスタム(CNAME)\n\n## 必要環境変数 (Vercel Dashboard > Project Settings > Environment Variables)\n| Key | Value (例) | Note |
+|-----|-----------|------|
+| NEXT_PUBLIC_SUPABASE_URL | https://xxxxx.supabase.co | Supabase プロジェクト URL |
+| NEXT_PUBLIC_SUPABASE_ANON_KEY | (Anon 公開鍵) | Public ANON Key |
+\n※ Prod / Preview / Dev 全てに設定 (差異があれば別管理)\n\n## Supabase Auth 設定 (Dashboard)\nAuth > URL Configuration:\n- Redirect URLs に以下追加: \n  - https://<vercel-app>.vercel.app/*\n  - http://localhost:3000/* (ローカル保持)\n- Password recovery リンク許可\n\n## Middleware 調整 (本番 E2E_MODE 無効化)
+```ts
+// middleware.ts (例)
+if (process.env.NODE_ENV === 'production') {
+  // ignore E2E_MODE block even if accidentally set
+}
+```
+(現状 E2E_MODE ブロックを条件でスキップする追記)\n\n## セキュリティヘッダ (例) next.config.ts
+```ts
+export default {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ];
+  },
+};
+```\n(必要に応じ CSP は後続)\n\n## デプロイ手順概要\n1. main ブランチ最新化 (auth helpers マージ済みであること)\n2. GitHub リポジトリを Vercel に Import\n3. Build Command: `npm run build` / Install Command: `npm install` / Output: `.next`\n4. 環境変数設定後 “Deploy”\n5. 完了後 URL で以下手動確認:\n   - 未ログインで /dashboard → /login リダイレクト\n   - 新規サインアップ → /onboarding 遷移\n   - onboarding 完了 → /profile or /dashboard\n   - リロードでセッション維持\n   - パスワードリセットフロー (メールリンク) 正常\n\n## 手動確認チェックリスト\n- [ ] /login でサインアップ成功\n- [ ] /dashboard 直アクセスで保護動作\n- [ ] /onboarding 完遂後 redirect 成功\n- [ ] /login へ戻ると /profile にリダイレクト (オンボード済)\n- [ ] パスワードリセットメール受信 & 成功\n- [ ] 404 ページ想定どおり\n\n## フォローアップ (別 Issue 案)\n- CI: GitHub Actions で build + lint + e2e\n- ログアウト導線 (signOut + 状態リセット)\n- CSP / Sentry / リアル E2E サインアップ自動化\n- ダークモード / Lighthouse パフォーマンス計測\n\n## 完了条件 (Definition of Done)\n- 本番 URL で上記手動チェック全項目 OK\n- main にヘッダ & E2E_MODE 無効化反映\n- Issue コメントに URL & 動作結果記録\n

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,7 +25,7 @@ export async function middleware(req: NextRequest) {
 	const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 	// Simulation mode for E2E
-	if (process.env.E2E_MODE === '1') {
+		if (process.env.E2E_MODE === '1' && process.env.NODE_ENV !== 'production') {
 		const e2eAuth = req.cookies.get('e2e-auth')?.value === '1'
 		const e2eOnboarded = req.cookies.get('e2e-onboarded')?.value === '1'
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要
Vercel 本番デプロイに向けた初期セットアップを追加。認証機能を含むアプリを安全に公開するための環境変数・ミドルウェア挙動・セキュリティヘッダを整備。

## 変更点
- issue-26-vercel-deploy.md: デプロイ手順 & チェックリスト & DoD 追加
- middleware.ts: 本番環境で `E2E_MODE` を強制無効化（誤設定によるバイパス防止）
- next.config.ts: 基本的なセキュリティヘッダ (X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy) 追加

## 目的
- 本番 URL 上で認証・オンボーディングの挙動を再現/検証できる状態を作る
- 余計なテストモード (E2E_MODE) の混入を防ぎ、安全な初期公開基盤を用意

## セットアップ (Vercel Dashboard)
環境変数 (Prod / Preview / Dev 全て):
| Key | Value |
|-----|-------|
| NEXT_PUBLIC_SUPABASE_URL | https://<project>.supabase.co |
| NEXT_PUBLIC_SUPABASE_ANON_KEY | <Anon Key> |

Supabase Auth Redirect URLs:
- https://<vercel-app>.vercel.app/*
- http://localhost:3000/*

## 手動確認チェック
- [ ] 未ログインで `/dashboard` → `/login`
- [ ] 新規サインアップ → `/onboarding`
- [ ] オンボーディング完了後 `/profile` or `/dashboard`
- [ ] `/login` (オンボード済) → `/profile` へ
- [ ] パスワードリセットメール成功
- [ ] 再読み込みでセッション維持
- [ ] 404 ページ期待通り
- [ ] レスポンスヘッダに X-Frame-Options / X-Content-Type-Options など付与

## リスク / 留意
- ログアウト UI まだ未実装（次 Issue）
- CSP / Sentry / CI/CD は未導入（後続強化）
- Header 追加による副作用（iframe 埋め込み不可）は意図どおり

## フォローアップ (別 Issue)
- ログアウト導線
- CI (build / lint / e2e) → main merge で自動デプロイ
- CSP + レポート機構
- E2E 実ユーザーフロー自動化
- Monitoring / Sentry

## DoD
- 上記チェック全て GREEN
- 本番 URL を Issue #26 に記録
- `E2E_MODE` が本番で無視されることを確認

レビュー観点:
- 本番で不要なテストモードが走らないか
- セキュリティヘッダ衝突の懸念 (無し)
- 追加したドキュメントの手順明確性

以上。必要ならログアウト Issue 下書きも続けて提示可能です。