### PR TITLE
Fix bundle analyzer lint violations

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import type { Configuration } from "webpack";
 
 const securityHeaders = [
   { key: 'X-Frame-Options', value: 'DENY' },
@@ -22,9 +23,10 @@ const nextConfig: NextConfig = {
   },
   // Bundle Analyzerの設定（開発用）
   ...(process.env['ANALYZE'] === 'true' && {
-    webpack: (config: any) => {
+    webpack: async (config: Configuration) => {
       if (process.env['ANALYZE']) {
-        const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+        const { BundleAnalyzerPlugin } = await import('webpack-bundle-analyzer');
+        config.plugins = config.plugins ?? [];
         config.plugins.push(
           new BundleAnalyzerPlugin({
             analyzerMode: 'static',


### PR DESCRIPTION
## Summary
- type the Next.js bundle analyzer webpack hook
- switch to ESM-friendly dynamic import and ensure plugins array exists when enabling the analyzer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddccdcb8ec8327af2078b91960516d